### PR TITLE
Thermonuclear bobm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 *.before
 dmdoc/
 cfg/
+data/character_info/
 build_log.txt
 use_map
 stopserver
@@ -47,3 +48,4 @@ lib/*.so
 *.pyc
 __pycache__
 maps/ministation/ministation-2BAK.dmm
+

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_age.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_age.dm
@@ -5,7 +5,7 @@
 		"a toddler" =      3,
 		"a child" =        7,
 		"a teenager" =    13,
-		"a young adult" = 17,
+		"a young adult" = 18,
 		"an adult" =      25,
 		"middle-aged" =   40,
 		"aging" =         55,

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -28,7 +28,7 @@
 	#include "../../mods/valsalia/_valsalia.dme"
 	#include "../../mods/species/neoavians/_neoavians.dme"
 	#include "../../mods/species/bayliens/_bayliens.dme"
-	//#include "../../mods/species/vox/_vox.dme"
+	#include "../../mods/species/vox/_vox.dme" //ChaosStation Readdition
 
 	#include "../away/bearcat/bearcat.dm"
 	#include "../away/casino/casino.dm"

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -1,5 +1,5 @@
 /datum/appearance_descriptor/age/neoavian
-	chargen_min_index = 3
+	chargen_min_index = 4
 	chargen_max_index = 6
 	standalone_value_descriptors = list(
 		"a hatchling" =     1,

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -1,12 +1,12 @@
 /datum/appearance_descriptor/age/serpentid
-	chargen_min_index = 3
-	chargen_max_index = 6
+	chargen_min_index = 5
+	chargen_max_index = 7
 	standalone_value_descriptors = list(
 		"a larva" =         1,
 		"a nymph" =         2,
 		"a juvenile" =      3,
 		"an adolescent" =   5,
-		"a young adult" =  12,
+		"a young adult" =  18,
 		"a full adult" =   30,
 		"senescent" =      45
 	)

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -1,12 +1,12 @@
 /datum/appearance_descriptor/age/vox
-	chargen_min_index = 3
+	chargen_min_index = 4
 	chargen_max_index = 6
 	standalone_value_descriptors = list(
 		"freshly spawned" =  1,
 		"a larva" =          2,
 		"a juvenile" =       5,
-		"an adolescent" =    8,
-		"an adult" =        12,
+		"an adolescent" =    14,
+		"an adult" =        18,
 		"senescent" =       50,
 		"withered" =        65
 	)

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -1,5 +1,5 @@
 /datum/appearance_descriptor/age/vox
-	chargen_min_index = 4
+	chargen_min_index = 5
 	chargen_max_index = 6
 	standalone_value_descriptors = list(
 		"freshly spawned" =  1,

--- a/mods/valsalia/species/yinglet_bodytype.dm
+++ b/mods/valsalia/species/yinglet_bodytype.dm
@@ -70,10 +70,10 @@
 	standalone_value_descriptors = list(
 		"a hatchling" =     1,
 		"an younglet" =     3,
-		"an adult" =        6,
-		"middle-aged" =    15,
-		"aging" =          25,
-		"elderly" =        30
+		"an adult" =        18,
+		"middle-aged" =    30,
+		"aging" =          45,
+		"elderly" =        50
 	)
 
 /decl/bodytype/yinglet/Initialize()


### PR DESCRIPTION
## Description of changes
-Fixes allowed character ages for ChaosStation policy and legal compliance

-Re-adds Vox as an allowed roundstart species

## Why and what will this PR improve
Laws, Ethics, Morals, and Birbs

## Authorship
All changes done by Fennec82/Arrhythmia_V

## Changelog
:cl: Arrhythmia_V
add: Vox now available roundstart
tweak: Character ages now (hopefully!) all ChaosStation and legally compliant
tweak: Characters now properly save
server: Me thinks characters only save upon round end and server shutdown
/:cl: